### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # GITHUB_TOKEN needs no scopes: repository-dispatch uses secrets.WEBHOOK_TOKEN; workflow does not check out code.
+    timeout-minutes: 30
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -13,8 +13,8 @@ jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
-    permissions: {} # GITHUB_TOKEN needs no scopes: repository-dispatch uses secrets.WEBHOOK_TOKEN; workflow does not check out code.
-    timeout-minutes: 30
+    permissions: {} # GITHUB_TOKEN needs no scopes: repository-dispatch uses secrets.WEBHOOK_TOKEN.
+    timeout-minutes: 5
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # GITHUB_TOKEN needs no scopes: repository-dispatch uses secrets.WEBHOOK_TOKEN; workflow does not check out code.
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 1 (`satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | f399fa7 |
| Timeouts commit | 986f86d |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-update.yml | 1 jobs were missing a scoped `permissions:` directive | webhook | `permissions: {}` (no granular scopes added; job does not clone the repo and `repository-dispatch` is invoked with `secrets.WEBHOOK_TOKEN`) [3] |


## Permissions corrections (previously incorrect)

No pre-existing configured `permissions:` were identified as incorrect.

## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-update.yml | webhook | `30` | The workflow only echoes derived values from the release payload and fires a repository-dispatch webhook; thirty minutes comfortably bounds a runaway job without restricting normal execution. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Attempt to fetch `peter-evans/repository-dispatch` `action.yml` at the pinned SHA timed out during this audit; permissio scope was inferred from the workflow YAML: explicit `secrets.WEBHOOK_TOKEN`, no checkout, no `github.token`/`GITHUB_TOKEN` passed to actions. If reviewers want zero ambiguity, confirming the pinned action revision does not read `GITHUB_TOKEN` from the environment when a custom token is supplied is recommended. |


